### PR TITLE
Should set Strict-Transport-Security headers on responses

### DIFF
--- a/modules/fastly-frontend/main.tf
+++ b/modules/fastly-frontend/main.tf
@@ -166,6 +166,24 @@ resource "fastly_service_v1" "fastly" {
     priority        = 10
   }
 
+  header {
+    name               = "HSTS"
+    type               = "response"
+    action             = "set"
+    destination        = "http.Strict-Transport-Security"
+    source             = "\"max-age=63072000; preload\""
+    priority           = 10
+    ignore_if_set      = true
+    response_condition = "hsts-if-force-ssl"
+  }
+
+  condition {
+    name      = "hsts-if-force-ssl"
+    type      = "RESPONSE"
+    priority  = 10
+    statement = var.force_ssl
+  }
+
   syslog {
     name               = "${local.full_domain_name}-syslog"
     address            = "intake.logs.datadoghq.com"


### PR DESCRIPTION
Teams conversation: https://teams.microsoft.com/l/message/19:bc474379f15f45d88c6eb2726125fdcb@thread.tacv2/1631886634550?tenantId=768fe7d4-ebee-41a7-9851-d5825ecdd396&groupId=17c05ab8-f302-4b26-a96f-22738ddfe231&parentMessageId=1631886634550&teamName=IONA%20-%20Platform&channelName=General&createdTime=1631886634550

We want to to add an HTTP header to responses (specifically a Strict-Transport-Security header) to indicate that a site should only be accessed over HTTPS.

Tom Yandell: _perhaps we should send an HSTS header for all products where force_ssl is set?_